### PR TITLE
[cli] Exit from the cli app if the HID device cannot be opened

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -122,7 +122,7 @@ int main(int argc, char *argv[]) {
   
   handle = hid_open(VID, PID, NULL);
   
-  if(i == 10){
+  if(i == 10 && handle != NULL){
     printf("\n> Unable to open the HID device.\n");
 		error = 1;
 		goto exit;


### PR DESCRIPTION
Fixes #8. 
BTW what is the preferred indentation in the cli? I see tabs, multiple number of spaces. I would like to clean it up if possible in a separate PR.