### PR TITLE
Fix HID device open failure handling

### DIFF
--- a/cli/main.c
+++ b/cli/main.c
@@ -133,7 +133,7 @@ int main(int argc, char *argv[]) {
   
   handle = hid_open(VID, PID, NULL);
   
-  if (i == 10 && handle != NULL) {
+  if (handle == NULL) {
     printf("\n> Unable to open the [%04X:%04X] device.\n",VID,PID);
     error = 1;
     goto exit;


### PR DESCRIPTION
When the ACM device could be opened to restart into the bootloader, but
the HID device was detected but failed to open (for example because of a
permission problem), this would not be detected and the code would
segfault because `handle` was NULL.

The code that was supposed to handle a NULL return value from `hid_open`
actually triggered only on a *non-null* value, and apparently also only
when the "looking for hid device" loop above had reached i = 10 (in
which case some error handling above would have bailed out already).

This changes the code to just check for a NULL return value, and bail
out in that case.