### PR TITLE
F1: bootloader-only-binaries create if not found in make

### DIFF
--- a/bootloader/F1/Makefile
+++ b/bootloader/F1/Makefile
@@ -212,6 +212,10 @@ $(BUILD_DIR):
 	$(ECHO) "MKDIR   $@"
 	$(Q)$(MKDIR) $@
 
+$(BIN_DIR):
+	$(ECHO) "MKDIR   $@"
+	$(Q)$(MKDIR) $@
+	
 clean:
 	$(ECHO) "CLEAN"
 	$(Q)$(RM) -f $(BUILD_DIR)/$(TARGET).elf


### PR DESCRIPTION
Fixes https://github.com/Serasidis/STM32_HID_Bootloader/issues/52 by creating `bootloader_only_binaries` if it doesn't exist.

Tested by removing `bootloader_only_binaries` then running `make generic-pc13`