### PR TITLE
F1: fixing usb issues from #64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ Temporary Items
 *.map
 *.size
 *.o
+/.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,4 @@ Temporary Items
 *.lst
 *.map
 *.size
+*.o

--- a/bootloader/F1/Makefile
+++ b/bootloader/F1/Makefile
@@ -9,6 +9,7 @@ VECTOR_TABLE_OFFSET = 0x0000
 PAGE_SIZE = 1024 
 
 C_SRCS = Src/main.c Src/usb.c Src/hid.c Src/led.c Src/flash.c
+DEVICE_C_SRCS += CMSIS/Device/ST/STM32F10x/Source/Templates/system_stm32f10x.c
 
 # Be silent per default, but 'make V=1' will show all compiler calls.
 # If you're insane, V=99 will print out all sorts of things.
@@ -22,6 +23,7 @@ INCLUDE_DIRS += -I Inc
 INCLUDE_DIRS += -I CMSIS/Device/ST/STM32F10x/Include 
 INCLUDE_DIRS += -I CMSIS/Include
 
+C_SRCS += $(DEVICE_C_SRCS)
 SRCS += $(C_SRCS)
 vpath %.c $(sort $(dir $(C_SRCS)))
 OBJS = $(addprefix $(BUILD_DIR)/,$(notdir $(C_SRCS:.c=.o)))

--- a/bootloader/F1/Src/usb.c
+++ b/bootloader/F1/Src/usb.c
@@ -28,7 +28,7 @@
 #include "usb.h"
 #include "hid.h"
 
-#define CNTR_MASK	(CNTR_RESETM | CNTR_SUSPM | CNTR_WKUPM)
+#define CNTR_MASK	(CNTR_CTRM | CNTR_RESETM | CNTR_SUSPM | CNTR_WKUPM)
 #define ISTR_MASK	(ISTR_CTR | ISTR_RESET | ISTR_SUSP | ISTR_WKUP)
 
 USB_RxTxBuf_t RxTxBuffer[MAX_EP_NUM];


### PR DESCRIPTION
Fixes #64 
not done; need to address size issue

Certain Blue Pills with fake STM32 chips had issues properly completing USB negotiations. Plugging them in resulted in a Device Descriptor Request failed error. 

This issue occurred even in the initial release and was fixed by making the same change made in [bootsector/stm32-hid-bootloader e58113c](https://github.com/bootsector/stm32-hid-bootloader/commit/e58113cdc8ca122f92f4751097271444aaf538cb); this fix only worked on older versions, however, thus another bug was known to be present. This was traced to 79c474e and was addressed by effectively reverting this commit. 

Doing so created another problem which is that the bootloader was now larger than 2KB. -> am working on figuring out some way to address this

